### PR TITLE
feature - get apps by (s)vip

### DIFF
--- a/eureka/get.go
+++ b/eureka/get.go
@@ -1,11 +1,12 @@
 package eureka
+
 import (
 	"encoding/xml"
 	"strings"
 )
 
 func (c *Client) GetApplications() (*Applications, error) {
-	response, err := c.Get("apps");
+	response, err := c.Get("apps")
 	if err != nil {
 		return nil, err
 	}
@@ -17,7 +18,7 @@ func (c *Client) GetApplications() (*Applications, error) {
 func (c *Client) GetApplication(appId string) (*Application, error) {
 	values := []string{"apps", appId}
 	path := strings.Join(values, "/")
-	response, err := c.Get(path);
+	response, err := c.Get(path)
 	if err != nil {
 		return nil, err
 	}
@@ -25,14 +26,39 @@ func (c *Client) GetApplication(appId string) (*Application, error) {
 	err = xml.Unmarshal(response.Body, application)
 	return application, err
 }
+
 func (c *Client) GetInstance(appId, instanceId string) (*InstanceInfo, error) {
 	values := []string{"apps", appId, instanceId}
 	path := strings.Join(values, "/")
-	response, err := c.Get(path);
+	response, err := c.Get(path)
 	if err != nil {
 		return nil, err
 	}
 	var instance *InstanceInfo = new(InstanceInfo)
 	err = xml.Unmarshal(response.Body, instance)
 	return instance, err
+}
+
+func (c *Client) GetVIP(vipId string) (*Applications, error) {
+	values := []string{"vips", vipId}
+	path := strings.Join(values, "/")
+	response, err := c.Get(path)
+	if err != nil {
+		return nil, err
+	}
+	var applications *Applications = new(Applications)
+	err = xml.Unmarshal(response.Body, applications)
+	return applications, err
+}
+
+func (c *Client) GetSVIP(svipId string) (*Applications, error) {
+	values := []string{"svips", svipId}
+	path := strings.Join(values, "/")
+	response, err := c.Get(path)
+	if err != nil {
+		return nil, err
+	}
+	var applications *Applications = new(Applications)
+	err = xml.Unmarshal(response.Body, applications)
+	return applications, err
 }


### PR DESCRIPTION
Adds two functions to get applications by (in)secureVIP.

Basically a replication of the `GetApplication` endpoint. I'm returning the plural `*Applications` because multiple apps can be registered to the same (S)VIP.