### PR TITLE
Compatibility with post-1.2.2 eureka instances

### DIFF
--- a/eureka/requests.go
+++ b/eureka/requests.go
@@ -106,6 +106,8 @@ func NewRawRequest(method, relativePath string, body []byte, cancel <-chan bool)
 func NewInstanceInfo(hostName, app, ip string, port int, ttl uint, isSsl bool) *InstanceInfo {
 	dataCenterInfo := &DataCenterInfo{
 		Name: "MyOwn",
+		Class:    "com.netflix.appinfo.InstanceInfo$DefaultDataCenterInfo",
+		Metadata: nil,
 	}
 	leaseInfo := &LeaseInfo{
 		EvictionDurationInSecs: ttl,

--- a/eureka/requests.go
+++ b/eureka/requests.go
@@ -67,7 +67,7 @@ type InstanceInfo struct {
 type DataCenterInfo struct {
 	Name     string             `xml:"name" json:"name"`
 	Class    string             `xml:"class,attr" json:"@class"`
-	Metadata DataCenterMetadata `xml:"metadata,omitempty" json:"metadata,omitempty"`
+	Metadata *DataCenterMetadata `xml:"metadata,omitempty" json:"metadata,omitempty"`
 }
 
 type DataCenterMetadata struct {


### PR DESCRIPTION
To make this client work with post-1.2.2 eureka instances some fixes are required:

* DataCenterInfo.Metadata has to be omitted if empty
* When dataCenterInfo is "MyOwn", `com.netflix.appinfo.InstanceInfo$DefaultDataCenterInfo` has to be set as Class

Otherwise eureka will reply with an error 400 and the client will not get registered