### PR TITLE
Detect instance not found when sending heartbeat

### DIFF
--- a/eureka/error.go
+++ b/eureka/error.go
@@ -7,10 +7,12 @@ import (
 
 const (
 	ErrCodeEurekaNotReachable = 501
+	ErrCodeInstanceNotFound   = 502
 )
 
 var (
 	errorMap = map[int]string{
+		ErrCodeInstanceNotFound:   "Instance resource not found",
 		ErrCodeEurekaNotReachable: "All the given peers are not reachable",
 	}
 )

--- a/eureka/put.go
+++ b/eureka/put.go
@@ -1,10 +1,21 @@
 package eureka
 
-import "strings"
+import (
+	"net/http"
+	"strings"
+)
 
 func (c *Client) SendHeartbeat(appId, instanceId string) error {
 	values := []string{"apps", appId, instanceId}
 	path := strings.Join(values, "/")
-	_, err := c.Put(path, nil)
-	return err
+	resp, err := c.Put(path, nil)
+	if err != nil {
+		return err
+	}
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		return newError(ErrCodeInstanceNotFound,
+			"Instance resource not found when sending heartbeat", 0)
+	}
+	return nil
 }


### PR DESCRIPTION
This can happen if for example the Eureka server
was restarted after the client registered. In that
case we can detect the error and register again.